### PR TITLE
perf(layout): reuse bar layout tables

### DIFF
--- a/BarMixin.lua
+++ b/BarMixin.lua
@@ -322,7 +322,7 @@ end
 ---@param moduleConfig table
 ---@param mode string
 ---@return table
-local function getStackedLayoutParams(self, globalConfig, moduleConfig, mode)
+local function getStackedLayoutParams(self, params, globalConfig, moduleConfig, mode)
     local isDetached = mode == C.ANCHORMODE_DETACHED
     if not isDetached then
         mode = C.ANCHORMODE_CHAIN
@@ -346,16 +346,44 @@ local function getStackedLayoutParams(self, globalConfig, moduleConfig, mode)
     local flippedPoint = growsUp and "TOPLEFT" or "BOTTOMLEFT"
     local anchorRelativePoint = (isDetached and isFirst) and anchorPoint or flippedPoint
 
-    return {
-        mode = mode,
-        anchor = anchor,
-        isFirst = isFirst,
-        anchorPoint = anchorPoint,
-        anchorRelativePoint = anchorRelativePoint,
-        offsetX = 0,
-        offsetY = growsUp and gap or -gap,
-        height = moduleConfig.height or globalConfig.barHeight,
-    }
+    params.mode = mode
+    params.anchor = anchor
+    params.isFirst = isFirst
+    params.anchorPoint = anchorPoint
+    params.anchorRelativePoint = anchorRelativePoint
+    params.offsetX = 0
+    params.offsetY = growsUp and gap or -gap
+    params.height = moduleConfig.height or globalConfig.barHeight
+    params.width = nil
+    return params
+end
+
+---@param self FrameProto
+---@return table
+local function getLayoutParams(self)
+    self._layoutParams = self._layoutParams or {}
+    return self._layoutParams
+end
+
+---@param anchors table[]
+---@param index number
+---@param point string
+---@param anchor Frame
+---@param relativePoint string
+---@param offsetX number|nil
+---@param offsetY number|nil
+local function setAnchorSpec(anchors, index, point, anchor, relativePoint, offsetX, offsetY)
+    local spec = anchors[index]
+    if not spec then
+        spec = {}
+        anchors[index] = spec
+    end
+
+    spec[1] = point
+    spec[2] = anchor
+    spec[3] = relativePoint
+    spec[4] = offsetX
+    spec[5] = offsetY
 end
 
 --- Default layout parameter calculation for chain/detached/free anchor modes.
@@ -365,22 +393,22 @@ function FrameProto:CalculateLayoutParams()
     local globalConfig = assert(self:GetGlobalConfig(), "global config required")
     local moduleConfig = assert(self:GetModuleConfig(), "module config required")
     local mode = moduleConfig.anchorMode or C.ANCHORMODE_CHAIN
+    local params = getLayoutParams(self)
     if mode == C.ANCHORMODE_FREE then
         local pos = EditMode.GetPosition(moduleConfig and moduleConfig.editModePositions)
-        return {
-            mode = C.ANCHORMODE_FREE,
-            anchor = UIParent,
-            isFirst = false,
-            anchorPoint = pos.point,
-            anchorRelativePoint = pos.point,
-            offsetX = pos.x,
-            offsetY = pos.y,
-            height = moduleConfig.height or globalConfig.barHeight,
-            width = moduleConfig.width or globalConfig.barWidth,
-        }
+        params.mode = C.ANCHORMODE_FREE
+        params.anchor = UIParent
+        params.isFirst = false
+        params.anchorPoint = pos.point
+        params.anchorRelativePoint = pos.point
+        params.offsetX = pos.x
+        params.offsetY = pos.y
+        params.height = moduleConfig.height or globalConfig.barHeight
+        params.width = moduleConfig.width or globalConfig.barWidth
+        return params
     end
 
-    return getStackedLayoutParams(self, globalConfig, moduleConfig, mode)
+    return getStackedLayoutParams(self, params, globalConfig, moduleConfig, mode)
 end
 
 --- Applies positioning to a frame based on layout parameters.
@@ -401,21 +429,27 @@ function FrameProto:ApplyFramePosition()
 
     local params = self:CalculateLayoutParams()
     local anchorCount = params.mode == C.ANCHORMODE_FREE and 1 or 2
-    local anchors = {}
+    self._layoutAnchors = self._layoutAnchors or {}
+    local anchors = self._layoutAnchors
     if params.mode == C.ANCHORMODE_FREE then
         assert(params.anchor ~= nil, "anchor required for free anchor mode")
     end
 
     local lp = params.anchorPoint or "TOPLEFT"
     local lr = params.anchorRelativePoint or "BOTTOMLEFT"
-    for i = 1, anchorCount do
-        anchors[i] = {
-            i == 1 and lp or self.ChainRightPoint(lp, "TOPRIGHT"),
+    setAnchorSpec(anchors, 1, lp, params.anchor, lr, params.offsetX, params.offsetY)
+    if anchorCount == 2 then
+        setAnchorSpec(
+            anchors,
+            2,
+            self.ChainRightPoint(lp, "TOPRIGHT"),
             params.anchor,
-            i == 1 and lr or self.ChainRightPoint(lr, "BOTTOMRIGHT"),
+            self.ChainRightPoint(lr, "BOTTOMRIGHT"),
             params.offsetX,
-            params.offsetY,
-        }
+            params.offsetY
+        )
+    else
+        anchors[2] = nil
     end
 
     FrameUtil.LazySetAnchors(frame, anchors)

--- a/BarMixin.lua
+++ b/BarMixin.lua
@@ -318,6 +318,7 @@ function FrameProto.NormalizeGrowDirection(direction)
 end
 
 ---@param self FrameProto
+---@param params table reused output table populated with layout parameters
 ---@param globalConfig table
 ---@param moduleConfig table
 ---@param mode string

--- a/Tests/FrameMixin_spec.lua
+++ b/Tests/FrameMixin_spec.lua
@@ -605,6 +605,41 @@ describe("FrameMixin real source", function()
         )
     end)
 
+    it("UpdateLayout reuses layout params and anchors across repeated passes", function()
+        local globalConfig = {
+            barHeight = 20,
+            barWidth = 180,
+            barBgColor = color(0, 0, 0, 0.5),
+            moduleGrowDirection = ns.Constants.GROW_DIRECTION_DOWN,
+            offsetY = 4,
+            updateFrequency = 0,
+        }
+        local moduleConfig = {
+            enabled = true,
+            anchorMode = ns.Constants.ANCHORMODE_CHAIN,
+            bgColor = color(0, 0, 0, 0.5),
+        }
+        ns.Addon.GetECMModule = function()
+            return nil
+        end
+
+        local mod = makeFreeModeModule(ns.Constants.CHAIN_ORDER[1], globalConfig, moduleConfig)
+
+        assert.is_true(mod:UpdateLayout("initial"))
+        local layoutParams = mod._layoutParams
+        local layoutAnchors = mod._layoutAnchors
+        local leftAnchor = layoutAnchors[1]
+        local rightAnchor = layoutAnchors[2]
+
+        assert.is_true(mod:UpdateLayout("repeat"))
+
+        assert.are.equal(layoutParams, mod._layoutParams)
+        assert.are.equal(layoutAnchors, mod._layoutAnchors)
+        assert.are.equal(leftAnchor, mod._layoutAnchors[1])
+        assert.are.equal(rightAnchor, mod._layoutAnchors[2])
+        assert.are.equal(2, mod.InnerFrame:GetNumPoints())
+    end)
+
     it("AddMixin skips Edit Mode registration when the module opts out", function()
         local registerCalls = 0
         local mod = {


### PR DESCRIPTION
**Implemented**
- Reuse per-module layout params and anchor specs in `FrameProto:CalculateLayoutParams` / `ApplyFramePosition`.
- Avoid transient table allocation on every base bar layout pass while preserving live-anchor comparison and external mutation detection in `FrameUtil.LazySetAnchors`.
- Add a focused regression covering repeated real-source layout passes.

**Performance improvement shortlist**
1. Reuse shared base bar layout params and anchor specs across layout passes. **Selected:** high impact because every managed bar uses this path; low effort because it stays inside `BarMixin`.
2. Pool `BuffBars` ordered-child entries instead of allocating `{ viewer:GetChildren() }` and wrapper tables on every layout.
3. Reuse `BuffBars` child anchor specs in `layoutBars` instead of building fresh two-anchor literals for each visible child.
4. Reuse `ExternalBars` child anchor specs in `layoutBars` for the same per-active-aura allocation reduction.
5. Skip redundant `StyleChildBar` calls for buff/external bars when style inputs and active spell identity are unchanged.
6. Cache resolved status-bar texture paths by texture key to avoid repeated LibSharedMedia lookups during refresh/layout.
7. Make resource and value tick layout lazy for unchanged tick position, size, and color so stable bars avoid repeated point/size writes.
8. Cache PowerBar class/spec-derived power-type decisions and invalidate on specialization changes instead of recalculating on every power update.
9. Update ExternalBars duration text only when the formatted display string changes, not on every 0.1s duration ticker tick.
10. Reuse active spell-data result buffers for options discovery paths that rebuild normalized key arrays from current bars.

**Validation**
- `/opt/homebrew/bin/busted Tests/FrameMixin_spec.lua`
- `/opt/homebrew/bin/busted Tests`
- `luacheck . -q`